### PR TITLE
feat: 🛠️  integrate deepseek R1 using OpenRouter 🥇 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ jobs:
         steps:
             - name: step-name
               id: step-id
-              uses: murtuzaalisurti/better@v2 # this is the ref of the github action - https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_iduses
+              uses: murtuzaalisurti/better@v3 # this is the ref of the github action - https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_iduses
               with:
                 repo-token: ${{ secrets.GITHUB_TOKEN }} # this is auto generated
                 ai-model-api-key: ${{ secrets.MODEL_API_KEY }} # make sure to set this in your repository secrets - /settings/secrets/actions (Settings > Secrets and Variables > Actions > Secrets Tab)
-                platform: 'openai'
+                platform: 'openai' # can be 'openai' | 'anthropic' | 'mistral' | 'openrouter'
                 delete-existing-review-by-bot: true #default is true
                 filesToIgnore: '**/*.env; .husky/**; .cache/**' # uses glob patterns (micromatch - https://github.com/micromatch/micromatch)
                 rules: |- # Rules to consider for code review
@@ -93,9 +93,9 @@ The `repo-token` is the authorization token of your repository. It is auto gener
 
 ### 2. `platform`
 
-The `platform` is the name of the AI platform you want to use. It can be either `openai` or `anthropic` or `mistral`.
+The `platform` is the name of the AI platform you want to use. It can be either `openai` or `anthropic` or `mistral` or `openrouter`.
 
-> *This action supports ***OpenAI***, ***Anthropic*** and ***Mistral*** models for now*.
+> *This action supports ***OpenAI***, ***Anthropic***, ***Mistral*** and ***Deepseek*** models*.
 
 ---
 
@@ -108,6 +108,7 @@ Example:
 - `OPEN_AI_KEY` as a secret with your OpenAI API key as a value.
 - `ANTHROPIC_KEY` as a secret with your Anthropic API key as a value.
 - `MISTRAL_KEY` as a secret with your Mistral API key as a value.
+- `OPENROUTER_KEY` as a secret with your OpenRouter API key as a value.
 
 They can be accessed in the workflow file using `${{ secrets.YOUR_KEY_NAME }}`.
 
@@ -115,7 +116,7 @@ They can be accessed in the workflow file using `${{ secrets.YOUR_KEY_NAME }}`.
 
 ### 4. `ai-model-name` (Optional)
 
-Specify the name of the model you want to use to generate suggestions. Fallbacks to `gpt-4o-2024-08-06` for OpenAI, `claude-3-5-sonnet-20241022` for Anthropic, and `pixtral-12b-2409` for Mistral if not specified. Here's a list of supported models:
+Specify the name of the model you want to use to generate suggestions. Fallbacks to `gpt-4o-2024-08-06` for OpenAI, `claude-3-5-sonnet-20241022` for Anthropic, `pixtral-12b-2409` for Mistral, and `deepseek/deepseek-r1` for OpenRouter if not specified. Here's a list of supported models:
 
 For OpenAI:
 
@@ -135,6 +136,10 @@ For Anthropic:
 For Mistral:
 
 - Any of the latest [models](https://docs.mistral.ai/getting-started/models/models_overview/).
+
+For OpenRouter:
+
+- [deepseek/deepseek-r1](https://openrouter.ai/deepseek/deepseek-r1).
 
 ---
 
@@ -162,11 +167,11 @@ List of files to ignore. It is a semicolon(`;`) separated list of glob patterns.
 **/*.{jpg,jpeg,png,svg,webp,avif,gif,ico,woff,woff2,ttf,otf}
 ```
 
+Glob patterns are resolved using [micromatch](https://github.com/micromatch/micromatch). Check out their documentation for more info.
+
 ### 8. `max-retries` (Optional)
 
-The maximum number of retries the action will perform on failure while generating suggestions from the AI model. Specify `0` to skip retries. The default value is `3` if you don't specify.
-
-Glob patterns are resolved using [micromatch](https://github.com/micromatch/micromatch). Check out their documentation for more info.
+The maximum number of retries the action will perform on failure while generating suggestions from the AI model. Specify `0` to skip retries (see things to note below to know why this is important). The default value is `3` if you don't specify.
 
 ---
 
@@ -174,5 +179,6 @@ Glob patterns are resolved using [micromatch](https://github.com/micromatch/micr
 
 - The more the pull request changes are in number, higher will be the tokens sent to the AI model and once you reach the token limit either for the model or for the API (rate limiting), the action will throw an error. So, make sure to upgrade your model or the token limit if you encounter an issue which states *too many tokens* or *token limit reached*. Visit respective platform's API documentation for more details.
 - The [system prompt](https://github.com/murtuzaalisurti/better/blob/main/utils/constants.js#L10) is common across all supported AI models.
+- The max retries option (new in v3) will make a call to the model at least 3 times if you don't specify the `max-retries` option in your workflow file. This will increase the consumption of tokens, so if you don't want to retry on failure, set the `max-retries` option to `0`.
 
 > Made with ❤️ by [@murtuzaalisurti](https://github.com/murtuzaalisurti). Learn more at [https://syntackle.com/blog/ai-powered-code-review-tool-better/](https://syntackle.com/blog/ai-powered-code-review-tool-better/).

--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ List of files to ignore. It is a semicolon(`;`) separated list of glob patterns.
 **/*.{jpg,jpeg,png,svg,webp,avif,gif,ico,woff,woff2,ttf,otf}
 ```
 
+### 8. `max-retries` (Optional)
+
+The maximum number of retries the action will perform on failure while generating suggestions from the AI model. Specify `0` to skip retries. The default value is `3` if you don't specify.
+
 Glob patterns are resolved using [micromatch](https://github.com/micromatch/micromatch). Check out their documentation for more info.
 
 ---

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
         description: "The repo token: { secrets.GITHUB_TOKEN }"
         required: true
     platform:
-        description: "The AI platform to use. Either `openai` or `anthropic`"
+        description: "The AI platform to use. Either `openai` or `anthropic` or `mistral` or `openrouter`."
         required: true
     ai-model-api-key:
         description: "The models api key: { secrets.<YOUR_AI_MODEL_API_KEY> }"

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,8 @@ inputs:
         description: "The rules to consider for code review"
     filesToIgnore:
         description: "List of files to ignore - a semicolon(;) separated list of glob patterns"
+    max-retries:
+        description: "Maximum number of retries on failure - default is 3 - 0 means no retries"
 runs:
     using: "node20"
     main: "dist/index.js"

--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ function getUserPrompt(rules, rawComments, pullRequestContext) {
  * @returns {Promise<suggestionsPayload | null>}
  */
 async function useOpenAI({ rawComments, openAI, rules, modelName, pullRequestContext, platform }) {
-    const modelDeepseek = /deepseek/i.test(modelName);
+    const modelDeepseek = /deepseek/i.test(getModelName(modelName, platform));
     const result = !modelDeepseek
         ? await openAI.beta.chat.completions.parse({
               model: getModelName(modelName, platform),
@@ -200,6 +200,9 @@ async function useOpenAI({ rawComments, openAI, rules, modelName, pullRequestCon
                       content: `${getUserPrompt(rules, rawComments, pullRequestContext)} - IMP: give the output in a valid JSON string and stick to the schema.`,
                   },
               ],
+              response_format: {
+                  type: "json_object",
+              },
           });
 
     const { message } = result.choices[0];

--- a/index.js
+++ b/index.js
@@ -348,6 +348,10 @@ async function retry(
     let lastError;
     let delay = initialDelay;
 
+    if (retries === 0) {
+        return await fn();
+    }
+
     for (let attempt = 0; attempt < retries; attempt++) {
         try {
             return await fn();

--- a/index.js
+++ b/index.js
@@ -457,13 +457,8 @@ async function getSuggestions({
             }
         );
     } catch (err) {
-        if (err.constructor.name == "LengthFinishReasonError") {
-            error(`Too many tokens: ${err.message}`);
-            core.setFailed(`Too many tokens: ${err.message}`);
-        } else {
-            error(`Could not generate suggestions: ${err.message}`);
-            core.setFailed(`Could not generate suggestions: ${err.message}`);
-        }
+        error(`Could not generate suggestions: ${err.message}`);
+        core.setFailed(`Could not generate suggestions: ${err.message}`);
         return null;
     }
 }

--- a/index.js
+++ b/index.js
@@ -184,7 +184,9 @@ async function useOpenAI({ rawComments, openAI, rules, modelName, pullRequestCon
                 content: `${getUserPrompt(rules, rawComments, pullRequestContext)} - IMP: give the output in a valid JSON string and stick to the schema.`,
             },
         ],
-        response_format: zodResponseFormat(diffPayloadSchema, "json_diff_response"),
+        response_format: /deepseek/i.test(modelName)
+            ? { type: "json_object" }
+            : zodResponseFormat(diffPayloadSchema, "json_diff_response"),
     });
 
     const { message } = result.choices[0];

--- a/index.js
+++ b/index.js
@@ -171,6 +171,7 @@ function getUserPrompt(rules, rawComments, pullRequestContext) {
  * @returns {Promise<suggestionsPayload | null>}
  */
 async function useOpenAI({ rawComments, openAI, rules, modelName, pullRequestContext }) {
+    console.log(modelName, "-- model ------");
     const result = await openAI.beta.chat.completions.parse({
         model: getModelName(modelName, "openai"),
         messages: [

--- a/index.js
+++ b/index.js
@@ -197,7 +197,23 @@ async function useOpenAI({ rawComments, openAI, rules, modelName, pullRequestCon
                   },
                   {
                       role: "user",
-                      content: `${getUserPrompt(rules, rawComments, pullRequestContext)} - IMP: give the output in a valid JSON string and stick to the schema.`,
+                      content: `${getUserPrompt(rules, rawComments, pullRequestContext)} - IMP: give the output in a valid JSON string and stick to the schema mentioned here: 
+                      {
+                        commentsToAdd: {
+                            path: string;
+                            position: number;
+                            line: number;
+                            change: {
+                                type: string;
+                                add: boolean;
+                                ln: number;
+                                content: string;
+                                relativePosition: number;
+                            };
+                            previously?: string | undefined;
+                            suggestions?: string | undefined;
+                        }[];
+                      }.`,
                   },
               ],
               response_format: {
@@ -213,7 +229,7 @@ async function useOpenAI({ rawComments, openAI, rules, modelName, pullRequestCon
         throw new Error(`the model refused to generate suggestions - ${message.refusal}`);
     }
 
-    return message.parsed;
+    return modelDeepseek ? JSON.parse(message.content) : message.parsed;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ import { AIMessage } from "@langchain/core/messages";
  * @typedef {InstanceType<GitHub>} OctokitApi
  * @typedef {parseDiff.File[]} ParsedDiff
  * @typedef {{ body: string | null }} PullRequestContext
- * @typedef {'openai' | 'anthropic' | 'mistral'} AIPlatform
+ * @typedef {'openai' | 'anthropic' | 'mistral' | 'openrouter'} AIPlatform
  * @typedef {OpenAI | Anthropic | ChatMistralAI<ChatMistralAICallOptions>} AIPlatformSDK
  * @typedef {{
  *  info: (message: string) => void,
@@ -323,6 +323,16 @@ async function getSuggestions({ platform, rawComments, platformSDK, rules, model
             });
         }
 
+        if (platform === "openrouter") {
+            return await useOpenAI({
+                rawComments,
+                openAI: platformSDK,
+                rules,
+                modelName,
+                pullRequestContext,
+            });
+        }
+
         throw new Error(`Unsupported AI platform: ${platform}`);
     } catch (err) {
         if (err.constructor.name == "LengthFinishReasonError") {
@@ -465,6 +475,7 @@ function getPlatformSDK(platform, apiKey) {
     if (platform === "openai") return new OpenAI({ apiKey });
     if (platform === "anthropic") return new Anthropic({ apiKey });
     if (platform === "mistral") return new ChatMistralAI({ apiKey });
+    if (platform === "openrouter") return new OpenAI({ apiKey, baseURL: "https://openrouter.ai/api/v1" });
 
     throw new Error(`Unsupported AI platform: ${platform}`);
 }

--- a/index.js
+++ b/index.js
@@ -197,7 +197,7 @@ async function useOpenAI({ rawComments, openAI, rules, modelName, pullRequestCon
                   },
                   {
                       role: "user",
-                      content: `${getUserPrompt(rules, rawComments, pullRequestContext)} - IMP: give the output in a valid JSON string and stick to the schema mentioned here: 
+                      content: `${getUserPrompt(rules, rawComments, pullRequestContext)} - IMP: give the output in a valid JSON string (it should be not be wrapped in markdown, just plain json object) and stick to the schema mentioned here: 
                       {
                         commentsToAdd: {
                             path: string;

--- a/index.js
+++ b/index.js
@@ -223,8 +223,6 @@ async function useOpenAI({ rawComments, openAI, rules, modelName, pullRequestCon
 
     const { message } = result.choices[0];
 
-    console.log(message);
-
     if (message.refusal) {
         throw new Error(`the model refused to generate suggestions - ${message.refusal}`);
     }

--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
 import core from "@actions/core";
 import github from "@actions/github";
-import parseDiff from "parse-diff";
 import OpenAI from "openai";
 import Anthropic from "@anthropic-ai/sdk";
 import { ChatMistralAI, ChatMistralAICallOptions } from "@langchain/mistralai";
+import { StructuredOutputParser } from "@langchain/core/output_parsers";
+import { AIMessage } from "@langchain/core/messages";
+import parseDiff from "parse-diff";
 import { zodResponseFormat } from "openai/helpers/zod";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
@@ -11,8 +13,6 @@ import mm from "micromatch";
 
 import { aDiff, diffPayloadSchema, diffPayloadSchemaWithRequiredSuggestions } from "./utils/types.js";
 import { DEFAULT_MODEL, COMMON_SYSTEM_PROMPT, FILES_IGNORED_BY_DEFAULT } from "./utils/constants.js";
-import { StructuredOutputParser } from "@langchain/core/output_parsers";
-import { AIMessage } from "@langchain/core/messages";
 
 /**
  * @typedef {import("@actions/github/lib/utils").GitHub} GitHub

--- a/index.js
+++ b/index.js
@@ -416,6 +416,7 @@ async function getSuggestions({
                         rules,
                         modelName,
                         pullRequestContext,
+                        platform,
                     });
                 }
 

--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ async function useOpenAI({ rawComments, openAI, rules, modelName, pullRequestCon
             },
             {
                 role: "user",
-                content: getUserPrompt(rules, rawComments, pullRequestContext),
+                content: `${getUserPrompt(rules, rawComments, pullRequestContext)} - IMP: give the output in a valid JSON string and stick to the schema.`,
             },
         ],
         response_format: zodResponseFormat(diffPayloadSchema, "json_diff_response"),

--- a/index.js
+++ b/index.js
@@ -293,6 +293,7 @@ async function useMistral({ rawComments, mistral, rules, modelName, pullRequestC
 async function getSuggestions({ platform, rawComments, platformSDK, rules, modelName, pullRequestContext }) {
     const { error } = log({ withTimestamp: true }); // eslint-disable-line no-use-before-define
 
+    console.log("getSuggestions ---", modelName);
     try {
         if (platform === "openai") {
             return await useOpenAI({

--- a/index.js
+++ b/index.js
@@ -166,14 +166,14 @@ function getUserPrompt(rules, rawComments, pullRequestContext) {
  *  openAI: OpenAI,
  *  rules: string,
  *  modelName: string,
- *  pullRequestContext: PullRequestContext
+ *  pullRequestContext: PullRequestContext,
+ *  platform: AIPlatform
  * }} params
  * @returns {Promise<suggestionsPayload | null>}
  */
-async function useOpenAI({ rawComments, openAI, rules, modelName, pullRequestContext }) {
-    console.log(modelName, "-- model ------");
+async function useOpenAI({ rawComments, openAI, rules, modelName, pullRequestContext, platform }) {
     const result = await openAI.beta.chat.completions.parse({
-        model: getModelName(modelName, "openai"),
+        model: getModelName(modelName, platform),
         messages: [
             {
                 role: "system",
@@ -293,7 +293,6 @@ async function useMistral({ rawComments, mistral, rules, modelName, pullRequestC
 async function getSuggestions({ platform, rawComments, platformSDK, rules, modelName, pullRequestContext }) {
     const { error } = log({ withTimestamp: true }); // eslint-disable-line no-use-before-define
 
-    console.log("getSuggestions ---", modelName);
     try {
         if (platform === "openai") {
             return await useOpenAI({
@@ -332,6 +331,7 @@ async function getSuggestions({ platform, rawComments, platformSDK, rules, model
                 rules,
                 modelName,
                 pullRequestContext,
+                platform,
             });
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "main": "index.js",
   "type": "module",
   "scripts": {

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -8,6 +8,9 @@ const DEFAULT_MODEL = {
     MISTRAL: {
         name: "pixtral-12b-2409",
     },
+    OPENROUTER: {
+        name: "deepseek/deepseek-r1",
+    },
 };
 
 const COMMON_SYSTEM_PROMPT = `


### PR DESCRIPTION
- use [OpenRouter](https://openrouter.ai/) as a platform
- integrate [deepseek R1](https://openrouter.ai/deepseek/deepseek-r1)
- the reason of using OpenRouter is it supports multiple providers with a single API key
- add retry mechanism with 3 retries by default